### PR TITLE
Update Shade plugin and have a reduced examples JAR

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -58,9 +58,66 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.1.1</version>
         <configuration>
-          <createDependencyReducedPom>false</createDependencyReducedPom>
+          <createDependencyReducedPom>true</createDependencyReducedPom>
+          
+          <!-- Make it tiny! -->
+          <minimizeJar>true</minimizeJar>
+          <filters>
+             <!-- These are needed by the examples to function. -->
+             <!--<filter>
+               <artifact>com.iopipe.example:iopipe-examples</artifact>
+               <includes>**</includes>
+             </filter>-->
+             <filter>
+               <artifact>com.iopipe:iopipe</artifact>
+               <includes>**</includes>
+             </filter>
+             <filter>
+               <artifact>org.glassfish:javax.json</artifact>
+               <includes>**</includes>
+             </filter>
+             <filter>
+               <artifact>org.apache.logging.log4j:*</artifact>
+               <includes>**</includes>
+             </filter>
+             <filter>
+               <artifact>com.amazonaws:aws-lambda-java-core</artifact>
+               <excludes>**</excludes>
+             </filter>
+             <filter>
+               <artifact>com.amazonaws:aws-lambda-java-events</artifact>
+               <includes>**</includes>
+             </filter>
+             <filter>
+               <artifact>com.amazonaws:aws-java-sdk-kinesis</artifact>
+               <includes>**</includes>
+             </filter>
+             
+             <!-- These are not needed by AWS as they are pre-included -->
+             <filter>
+               <artifact>com.amazonaws:aws-java-sdk-core</artifact>
+               <excludes>**</excludes>
+             </filter>
+             <filter>
+               <artifact>com.fasterxml.jackson.core:jackson-databind</artifact>
+               <excludes>**</excludes>
+             </filter>
+             <filter>
+               <artifact>com.fasterxml.jackson.core:jackson-annotations</artifact>
+               <excludes>**</excludes>
+             </filter>
+             <filter>
+               <artifact>com.fasterxml.jackson.core:jackson-core</artifact>
+               <excludes>**</excludes>
+             </filter>
+             <filter>
+               <artifact>com.fasterxml.jackson.dataformat:jackson-dataformat-cbor</artifact>
+               <excludes>**</excludes>
+             </filter>
+          </filters>
+          
         </configuration>
         <executions>
           <execution>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -60,16 +60,26 @@
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.1.1</version>
         <configuration>
-          <createDependencyReducedPom>true</createDependencyReducedPom>
           
-          <!-- Make it tiny! -->
+          <!-- The following settings can be used to create a JAR which is -->
+          <!-- smaller in size, this can be used in the event that the JAR -->
+          <!-- is too big for Amazon Lambda. -->
+          <!-- Note that the setup here works for this example project and -->
+          <!-- it may or may not work for other projects if they add more -->
+          <!-- dependencies. Running the resulting JAR may work on some -->
+          <!-- invocations or it may fail on other invocations depending -->
+          <!-- on the classes available that can be initialized. -->
+          <!-- If an invocation fails with NoClassDefFoundError or -->
+          <!-- ExceptionInInitializationError then a class which is -->
+          <!-- required has not been included. Going through the project -->
+          <!-- dependency tree you should be able to determine the project -->
+          <!-- that must be included. -->
+          <!-- Or, this entire section can just not be included in which -->
+          <!-- case any issues that might arrive will not occur. -->
+          <createDependencyReducedPom>true</createDependencyReducedPom>
           <minimizeJar>true</minimizeJar>
           <filters>
-             <!-- These are needed by the examples to function. -->
-             <!--<filter>
-               <artifact>com.iopipe.example:iopipe-examples</artifact>
-               <includes>**</includes>
-             </filter>-->
+             <!-- These are needed by IOpipe and the examples to function. -->
              <filter>
                <artifact>com.iopipe:iopipe</artifact>
                <includes>**</includes>
@@ -117,6 +127,7 @@
                <excludes>**</excludes>
              </filter>
           </filters>
+          <!-- End of JAR size reduction. -->
           
         </configuration>
         <executions>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.iopipe</groupId>
       <artifactId>iopipe</artifactId>
-      <version>1.4.0-SNAPSHOT</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,25 +61,17 @@
         <version>3.1.1</version>
         <configuration>
           
-          <!-- The following settings can be used to create a JAR which is -->
-          <!-- smaller in size, this can be used in the event that the JAR -->
-          <!-- is too big for Amazon Lambda. -->
-          <!-- Note that the setup here works for this example project and -->
-          <!-- it may or may not work for other projects if they add more -->
-          <!-- dependencies. Running the resulting JAR may work on some -->
-          <!-- invocations or it may fail on other invocations depending -->
-          <!-- on the classes available that can be initialized. -->
-          <!-- If an invocation fails with NoClassDefFoundError or -->
-          <!-- ExceptionInInitializationError then a class which is -->
-          <!-- required has not been included. Going through the project -->
-          <!-- dependency tree you should be able to determine the project -->
-          <!-- that must be included. -->
-          <!-- Or, this entire section can just not be included in which -->
-          <!-- case any issues that might arrive will not occur. -->
+          <!-- This following group of settings can be used to reduce the size
+               of the JAR, it is optional and is not required to be used.
+               The setup described here may or may not work depending on the
+               project, if an invocation fails with NoClassDefFoundError or
+               ExceptionInInitializationError then a required dependency is
+               missing and must be explicitely included. -->
           <createDependencyReducedPom>true</createDependencyReducedPom>
           <minimizeJar>true</minimizeJar>
           <filters>
-             <!-- These are needed by IOpipe and the examples to function. -->
+             <!-- These dependencies are required to be included otherwise the
+                  shade plugin will exclude them. -->
              <filter>
                <artifact>com.iopipe:iopipe</artifact>
                <includes>**</includes>
@@ -105,7 +97,8 @@
                <includes>**</includes>
              </filter>
              
-             <!-- These are not needed by AWS as they are pre-included -->
+             <!-- These dependencies are not required and may be excluded
+                  from the JAR, Amazon includes these in the classpath. -->
              <filter>
                <artifact>com.amazonaws:aws-java-sdk-core</artifact>
                <excludes>**</excludes>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -66,7 +66,7 @@
                The setup described here may or may not work depending on the
                project, if an invocation fails with NoClassDefFoundError or
                ExceptionInInitializationError then a required dependency is
-               missing and must be explicitely included. -->
+               missing and must be explicitly included. -->
           <createDependencyReducedPom>true</createDependencyReducedPom>
           <minimizeJar>true</minimizeJar>
           <filters>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.iopipe</groupId>
       <artifactId>iopipe</artifactId>
-      <version>1.3.0</version>
+      <version>1.4.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
This was something that I worked on in May. This updates the shade plugin (which should be updated anyway since it supports Java 8). Additionally this has a guide for creating a reduced JAR which for the example project is currently half of its original size. It is optional and I have a large note detailing the caveats of it and what to do in the event something goes wrong. So it can be used as a basis in the event the JAR is too large for Amazon and it needs to be reduced.