### PR TITLE
Include missing Java dependencies in the shading

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -120,6 +120,10 @@
                <artifact>joda-time:joda-time</artifact>
                <includes>**</includes>
              </filter>
+             <filter>
+               <artifact>org.tinylog:tinylog</artifact>
+               <includes>**</includes>
+             </filter>
              
              <!-- These dependencies are not required and may be excluded
                   from the JAR, Amazon includes these in the classpath. -->

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -129,7 +129,7 @@
                <includes>**</includes>
              </filter>
              <filter>
-               <artifact>com.squareup.okhttp3:okio</artifact>
+               <artifact>com.squareup.okio:okio</artifact>
                <includes>**</includes>
              </filter>
              

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -125,10 +125,6 @@
                <includes>**</includes>
              </filter>
              <filter>
-               <artifact>org.tinylog:tinylog</artifact>
-               <includes>**</includes>
-             </filter>
-             <filter>
                <artifact>com.squareup.okhttp3:okhttp</artifact>
                <includes>**</includes>
              </filter>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -124,6 +124,14 @@
                <artifact>org.tinylog:tinylog</artifact>
                <includes>**</includes>
              </filter>
+             <filter>
+               <artifact>org.tinylog:tinylog</artifact>
+               <includes>**</includes>
+             </filter>
+             <filter>
+               <artifact>com.squareup.okhttp3:okhttp</artifact>
+               <includes>**</includes>
+             </filter>
              
              <!-- These dependencies are not required and may be excluded
                   from the JAR, Amazon includes these in the classpath. -->

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -101,6 +101,10 @@
                <includes>**</includes>
              </filter>
              <filter>
+               <artifact>com.amazonaws:aws-java-sdk-s3</artifact>
+               <includes>**</includes>
+             </filter>
+             <filter>
                <artifact>com.fasterxml.jackson.core:jackson-databind</artifact>
                <includes>**</includes>
              </filter>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -128,6 +128,10 @@
                <artifact>com.squareup.okhttp3:okhttp</artifact>
                <includes>**</includes>
              </filter>
+             <filter>
+               <artifact>com.squareup.okhttp3:okio</artifact>
+               <includes>**</includes>
+             </filter>
              
              <!-- These dependencies are not required and may be excluded
                   from the JAR, Amazon includes these in the classpath. -->


### PR DESCRIPTION
IOpipe depends on more libraries which if the generic handler is used they are not included, so include them explicitly in the example POM.