### PR TITLE
Update iopipe to 1.7.2 version (Python)

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2017.7.27.1
 chardet==3.0.4
 idna==2.5
-iopipe==0.6.1
+iopipe==1.7.2
 monotonic==1.3
 requests==2.18.3
 urllib3==1.22


### PR DESCRIPTION
updated iopipe-python to latest version (https://github.com/iopipe/iopipe-python/releases) 